### PR TITLE
Updated the data format to handle NZ daylight savings.

### DIFF
--- a/lib/wits/final_interim_prices.rb
+++ b/lib/wits/final_interim_prices.rb
@@ -62,8 +62,13 @@ module Wits
     end
 
     def process_prices(csv, date)
+      times = []
+
       csv.map do |time, trading_period, price|
-        format_price(date, time, trading_period, price)
+        repeated_time = times.include?(time)
+        times << time
+
+        format_price(date, time, trading_period, price, repeated_time)
       end
     end
   end

--- a/lib/wits/five_minute_prices.rb
+++ b/lib/wits/five_minute_prices.rb
@@ -78,8 +78,13 @@ module Wits
     end
 
     def process_five_min_prices(csv)
+      times = []
+
       csv.map do |_node, date, trading_period, time, price, *_|
-        format_price(date, time, trading_period, price)
+        repeated_time = times.include?(time)
+        times << time
+
+        format_price(date, time, trading_period, price, repeated_time)
       end
     end
   end

--- a/spec/lib/wits/five_minute_prices_spec.rb
+++ b/spec/lib/wits/five_minute_prices_spec.rb
@@ -38,7 +38,7 @@ describe Wits::FiveMinutePrices do
 
       context 'averaged prices' do
         subject(:response) { Wits::FiveMinutePrices.five_minute_prices('BEN2201', date, :average) }
-        subject(:price)    { response[:prices][7] }
+        subject(:price)    { response[:prices][3] }
 
         it 'is able to make a live request' do
           expect(response).to be_a Hash
@@ -52,8 +52,8 @@ describe Wits::FiveMinutePrices do
           expect(response[:date]).to            eq date
           expect(response[:prices].length).to   be_within(2).of(48)
 
-          expect(price[:time]).to           eq parse_nz_time(Time.parse("#{date} 03:30"))
-          expect(price[:trading_period]).to eq 8
+          expect(price[:time]).to           eq parse_nz_time(Time.parse("#{date} 01:30"))
+          expect(price[:trading_period]).to eq 4
           expect(price[:price]).to          be_a(Float)
         end
       end


### PR DESCRIPTION
The CSV files provided by WITs does not explicitly communicate the time zone or UTC offset. When daylight savings ends, there will be CSV rows that share the same time (e.g. 2:00 am and 2:30 am when the clock moves back to 2am at 3am).

Therefore we need to infer whether the duplicate times are in daylight savings.
